### PR TITLE
Redesign podcast archive page (hero + large episode cards)

### DIFF
--- a/archive-podcasts.php
+++ b/archive-podcasts.php
@@ -1,98 +1,96 @@
 <?php
 
 /**
- * The template for displaying pages
+ * Podcast archive — redesigned episode listing.
+ *
+ * Hero (gradient title + search) followed by a vertical stack of large
+ * episode cards (thumbnail + body), then numbered pagination. The site
+ * header/footer (nav, About, Support, footer) come from header.php /
+ * footer.php, so they're intentionally not repeated here. Styling lives
+ * in style.css under the `pa__` namespace; fonts (Chivo/Mulish) and the
+ * accent are shared with the Latest Episodes redesign.
  *
  * @package CardanoPress Bootstrap
  * @since 0.1.0
  */
 
 get_header();
-
 ?>
 
+<main class="podcast-archive <?php echo cardanopress_bootstrap_class( 'content-full' ); ?>">
 
-    <div class="archive-header pt-5">
-        <div class="container">
-            <div class="row justify-content-md-center">
-                <div class="col-md-8 text-center">
-                    <h1>Learn Cardano Podcast Episode Archives</h1>
-                    <p>View all of the latest episodes produced by the Learn Cardano Podcast.</p>
-                    <div class="col-lg-10 m-auto pt-3">
-                        <?php get_search_form(); ?>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
+	<section class="pa__hero">
+		<h1 class="pa__h1">Learn Cardano Podcast Episode Archives</h1>
+		<p class="pa__sub">View all of the latest episodes produced by the Learn Cardano Podcast.</p>
+		<form class="pa__search" role="search" method="get" action="<?php echo esc_url( home_url( '/' ) ); ?>">
+			<label class="sr-only" for="pa-search"><?php echo esc_html_x( 'Search episodes', 'label', 'learncardano' ); ?></label>
+			<input id="pa-search" class="pa__search-input" type="search" name="s" value="<?php echo esc_attr( get_search_query() ); ?>" placeholder="Search episodes">
+			<input type="hidden" name="post_type" value="podcasts">
+			<button class="pa__search-btn" type="submit">Search</button>
+		</form>
+	</section>
 
-    <main class="podcast-category <?php echo cardanopress_bootstrap_class( 'content-full' ); ?>">
+	<section class="pa__wrap">
+		<?php if ( have_posts() ) : ?>
+			<div class="pa__list">
+				<?php
+				$is_first_page = ( absint( get_query_var( 'paged' ) ) <= 1 );
+				$i = 0;
+				while ( have_posts() ) :
+					the_post();
+					$title_attr  = the_title_attribute( array( 'echo' => false ) );
+					$thumb       = esc_url( lc_episode_thumb_url( 'large' ) );
+					$permalink   = esc_url( get_permalink() );
+					$date        = esc_html( get_the_date( 'd M, Y' ) );
+					$is_newest   = ( $is_first_page && 0 === $i );
+					$comments_no = get_comments_number();
+					?>
+					<a class="pa__card" href="<?php echo $permalink; ?>" aria-label="<?php echo esc_attr( $title_attr ); ?>">
+						<div class="pa__media<?php echo $is_newest ? ' pa__media--newest' : ''; ?>">
+							<div class="pa__media-img" style="background-image:url('<?php echo $thumb; ?>')" role="img" aria-label="<?php echo esc_attr( $title_attr ); ?>"></div>
+							<?php if ( $is_newest ) : ?>
+								<span class="pa__badge">Newest</span>
+							<?php endif; ?>
+							<span class="pa__play" aria-hidden="true">
+								<span class="pa__play-circle"><span class="pa__play-tri"></span></span>
+							</span>
+						</div>
+						<div class="pa__body">
+							<div class="pa__date"><?php echo $date; ?></div>
+							<h3 class="pa__title"><?php the_title(); ?></h3>
+							<p class="pa__excerpt"><?php echo esc_html( wp_trim_words( get_the_excerpt(), 34 ) ); ?></p>
+							<div class="pa__actions">
+								<span class="pa__btn">
+									<span class="pa__btn-tri" aria-hidden="true"></span>
+									Play episode
+								</span>
+								<span class="pa__comments"><?php printf( esc_html( _n( '%s comment', '%s comments', $comments_no, 'learncardano' ) ), number_format_i18n( $comments_no ) ); ?></span>
+							</div>
+						</div>
+					</a>
+					<?php
+					$i++;
+				endwhile;
+				?>
+			</div>
 
-        <div class="latest section">
-            <div class="container">
+			<?php
+			the_posts_pagination( array(
+				'mid_size'           => 1,
+				'end_size'           => 1,
+				'prev_text'          => '&larr; Prev',
+				'next_text'          => 'Next &rarr;',
+				'screen_reader_text' => __( 'Episodes navigation', 'learncardano' ),
+			) );
+			?>
 
-                <div class="episode-list ">
+		<?php else : ?>
+			<p class="pa__empty">No episodes found.</p>
+		<?php endif; ?>
+	</section>
 
-                    <div class="row  justify-content-md-center">
-                        <div class="col-md-10">
-
-                            <?php if ( have_posts() ) : ?>
-                                <?php while ( have_posts() ) : the_post(); ?>
-                                    <article id="<?php echo $post_type . '-' . get_the_ID(); ?>" class="">
-
-                                        <div class="episode-card">
-
-                                            <div class="row">
-                                                <div class="col-12 episode-details">
-                                                    <div class="row metadata">
-                                                        <div class="episode-tags col">
-    <?php echo get_the_term_list( $post->ID, 'ptag', '<span class="badge rounded-pill text-bg-primary">', ',</span> <span class="badge rounded-pill text-bg-primary">', '</span>' );
-        ?></span>
-                                                        </div>
-                                                        <div class="episode-date col text-end"> <?php the_time('d M, Y') ?></div>
-                                                    </div>
-
-
-                                                    <div class="episode-title">
-                                                        <h3 id="post-<?php the_ID(); ?>">
-                                                            <a href="<?php the_permalink() ?>" rel="bookmark" title="Permanent Link to <?php the_title_attribute(); ?>">
-                                                                <?php the_title(); ?></a>
-                                                        </h3>
-                                                    </div>
-                                                    <div class="episode-excerpt">
-                                                        <?php the_excerpt(); ?>
-                                                    </div>
-                                                    <a href="<?php the_permalink() ?>" class="btn btn-primary"  rel="bookmark" title="Permanent Link to <?php the_title_attribute(); ?>">
-                                                        <span class="fa fa-play"></span> Play episode
-                                                    </a> <a  href="<?php the_permalink() ?>#comments"  class="btn-secondary btn"><span class="fa fa-comment"></span> <?php printf( _n( '%d comment', '%d comments', get_comments_number(), 'learncardano' ), get_comments_number() ); ?></a>
-
-                                                </div>
-                                            </div>
-
-                                        </div>
-
-
-                                    </article><!-- #single-<?php the_ID(); ?> -->
-
-
-
-                                <?php endwhile; ?>
-
-                                <?php the_posts_pagination(); ?>
-
-                            <?php endif; ?>
-
-                        </div>
-                    </div>
-
-                </div>
-
-            </div>
-        </div>
-
-    </main><!-- .content -->
+</main><!-- .podcast-archive -->
 
 <?php
 
 get_footer();
-

--- a/functions.php
+++ b/functions.php
@@ -121,6 +121,20 @@ function enable_proposal_comments()
 }
 
 /**
+ * Resolve an episode's thumbnail URL, falling back to the bundled cover art.
+ * Shared by the home Latest Episodes section and the podcast archive.
+ */
+if ( ! function_exists( 'lc_episode_thumb_url' ) ) {
+	function lc_episode_thumb_url( $size = 'medium_large' ) {
+		$url = get_the_post_thumbnail_url( get_the_ID(), $size );
+		if ( ! $url ) {
+			$url = get_stylesheet_directory_uri() . '/images/learn-cardano-podcast-cover.jpg';
+		}
+		return $url;
+	}
+}
+
+/**
  * Dequeue plugin assets on pages that don't need them.
  *
  * The site loads ~18 render-blocking stylesheets on every page from

--- a/style.css
+++ b/style.css
@@ -91,3 +91,64 @@ body{font-family:"Open Sans",sans-serif;color:#222 !important}h1,h2,h3,.navbar-b
   .lep__sub{font-size:14.5px}
   .lep__all{font-size:14px;padding:11px 20px}
 }
+
+/* ============================================================
+   Podcast archive redesign (archive-podcasts.php, .pa__ namespace)
+   Shares Chivo/Mulish + accent with the Latest Episodes redesign.
+   ============================================================ */
+.podcast-archive{background:#f4f4f6;font-family:'Mulish',sans-serif;color:#15151a}
+.podcast-archive .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);border:0}
+
+/* hero */
+.pa__hero{text-align:center;padding:64px 24px 8px}
+.pa__h1{font-family:'Chivo',sans-serif;font-weight:900;font-size:44px;line-height:1.05;letter-spacing:-0.02em;margin:0 0 14px;background:linear-gradient(90deg,#dc10ff 0%,#0070ff 100%);-webkit-background-clip:text;background-clip:text;-webkit-text-fill-color:transparent;color:transparent}
+.pa__sub{font-size:16.5px;line-height:1.6;color:#5b5b63;max-width:560px;margin:0 auto 28px}
+.pa__search{display:flex;gap:10px;max-width:520px;margin:0 auto;padding:0 8px}
+.pa__search-input{flex:1;min-width:0;height:48px;border:1px solid #dcdce1;border-radius:10px;padding:0 18px;font-family:'Mulish',sans-serif;font-size:15px;color:#15151a;background:#fff;outline:none}
+.pa__search-input:focus{border-color:#9333ea}
+.pa__search-btn{flex:none;height:48px;padding:0 26px;border:none;border-radius:10px;background:#9333ea;color:#fff;font-family:'Mulish',sans-serif;font-size:15px;font-weight:700;cursor:pointer;transition:background .18s ease}
+.pa__search-btn:hover{background:#7a23c9;color:#fff}
+
+/* card list */
+.pa__wrap{max-width:1080px;margin:0 auto;padding:44px 24px 8px}
+.pa__list{display:flex;flex-direction:column;gap:24px}
+.pa__card{display:grid;grid-template-columns:1.02fr 1fr;background:#fff;border-radius:18px;overflow:hidden;text-decoration:none;box-shadow:0 1px 3px rgba(20,20,30,0.06);transition:box-shadow .22s ease,transform .22s ease}
+.pa__card:hover{box-shadow:0 22px 48px rgba(20,20,30,0.14);transform:translateY(-3px)}
+
+/* media */
+.pa__media{position:relative;min-height:300px;overflow:hidden;background:#16161d}
+.pa__media-img{position:absolute;inset:0;background-size:cover;background-position:center}
+.pa__badge{position:absolute;top:18px;left:18px;z-index:2;background:#9333ea;color:#fff;font-family:'Mulish',sans-serif;font-size:11.5px;font-weight:800;letter-spacing:0.12em;text-transform:uppercase;padding:7px 14px;border-radius:8px}
+.pa__play{position:absolute;inset:0;z-index:2;display:flex;align-items:center;justify-content:center}
+.pa__play-circle{width:68px;height:68px;border-radius:50%;background:rgba(255,255,255,0.92);display:flex;align-items:center;justify-content:center;box-shadow:0 8px 22px rgba(0,0,0,0.32)}
+.pa__play-tri{display:inline-block;width:0;height:0;border-top:12px solid transparent;border-bottom:12px solid transparent;border-left:19px solid #15151a;margin-left:5px}
+
+/* body */
+.pa__body{display:flex;flex-direction:column;justify-content:center;padding:40px 46px}
+.pa__date{font-family:'Mulish',sans-serif;font-size:12.5px;font-weight:700;letter-spacing:0.08em;text-transform:uppercase;color:#9333ea;margin-bottom:13px}
+.pa__title{font-family:'Chivo',sans-serif;font-weight:900;font-size:27px;line-height:1.14;letter-spacing:-0.02em;color:#15151a;margin:0 0 14px}
+.pa__excerpt{font-family:'Mulish',sans-serif;font-size:15px;line-height:1.6;color:#5e5e66;margin:0 0 26px;display:-webkit-box;-webkit-line-clamp:3;-webkit-box-orient:vertical;overflow:hidden}
+.pa__actions{display:flex;align-items:center;gap:20px}
+.pa__btn{display:inline-flex;align-items:center;gap:11px;background:#9333ea;color:#fff;font-family:'Mulish',sans-serif;font-size:14.5px;font-weight:700;padding:12px 24px;border-radius:9px}
+.pa__btn-tri{display:inline-block;width:0;height:0;border-top:6px solid transparent;border-bottom:6px solid transparent;border-left:10px solid #fff}
+.pa__comments{font-size:13.5px;font-weight:600;color:#8a8a90}
+
+/* pagination (WP the_posts_pagination markup) */
+.podcast-archive .pagination{display:flex;justify-content:center;padding:46px 0 8px}
+.podcast-archive .pagination .nav-links{display:flex;align-items:center;gap:8px;flex-wrap:wrap;justify-content:center}
+.podcast-archive .pagination .page-numbers{min-width:42px;height:42px;display:inline-flex;align-items:center;justify-content:center;padding:0 14px;border-radius:9px;background:#fff;border:1px solid #e3e3e8;color:#15151a;font-family:'Mulish',sans-serif;font-size:14.5px;font-weight:700;text-decoration:none}
+.podcast-archive .pagination .page-numbers.current{background:#9333ea;border-color:#9333ea;color:#fff}
+.podcast-archive .pagination .page-numbers.dots{border:none;background:transparent;color:#a3a3aa;min-width:0;padding:0 4px}
+.podcast-archive .pagination a.page-numbers:hover{border-color:#9333ea;color:#9333ea}
+.pa__empty{text-align:center;color:#5e5e66;padding:40px 0}
+
+/* mobile */
+@media (max-width:780px){
+  .pa__hero{padding:44px 18px 4px}
+  .pa__h1{font-size:34px}
+  .pa__wrap{padding:28px 16px 4px}
+  .pa__card{grid-template-columns:1fr}
+  .pa__media{min-height:0;aspect-ratio:16/9}
+  .pa__body{padding:26px 24px 30px}
+  .pa__title{font-size:22px}
+}

--- a/template-parts/home-podcasts.php
+++ b/template-parts/home-podcasts.php
@@ -22,18 +22,7 @@ if ( ! $query->have_posts() ) {
 	return;
 }
 
-/**
- * Resolve the episode thumbnail URL, falling back to the bundled cover art.
- */
-if ( ! function_exists( 'lc_episode_thumb_url' ) ) {
-	function lc_episode_thumb_url( $size = 'medium_large' ) {
-		$url = get_the_post_thumbnail_url( get_the_ID(), $size );
-		if ( ! $url ) {
-			$url = get_stylesheet_directory_uri() . '/images/learn-cardano-podcast-cover.jpg';
-		}
-		return $url;
-	}
-}
+// lc_episode_thumb_url() is defined in functions.php (shared with the archive).
 
 $index = 0;
 ?>


### PR DESCRIPTION
Implements the Podcast Archive Page design handoff:
- Hero with gradient H1 + supporting copy + a podcast-scoped search form (input + Search button, posts ?s=&post_type=podcasts).
- Vertical stack of large episode cards: thumbnail (cover image with play overlay; 'Newest' badge on the first card of page 1) beside a body with date, title, 3-line excerpt, Play button and comment count.
- Numbered pagination styled to match (accent current page).

Only the page's own content is implemented here — the nav, About, Support (Delegate) and footer shown in the mockup already come from header.php / footer.php, so they're not duplicated.

Reuses the self-hosted Chivo/Mulish fonts and #9333ea accent added for the Latest Episodes redesign. Styling is namespaced under .pa__ in style.css. The shared lc_episode_thumb_url() helper moved from the home partial into functions.php so both templates use it. No inline styles (the per-card background-image URL is data, not styling).